### PR TITLE
Working deploy.sh script for other shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a wrapper for TIDAL's web app, using Nativfier, which injects custom cod
 ## Installation
 
 ### From binary
-[![Download link](https://img.shields.io/badge/Github-Download-blue.svg?style=for-the-badge&logo=github)](https://github.com/rippin93/tidal-desktop/releases/latest)
+[![Download link](https://img.shields.io/badge/Github-Download-blue.svg?style=for-the-badge&logo=github)](https://github.com/dxwil/tidal-desktop-gnome/releases/latest)
 
 Click the above tag, or go to the releases tab, and download the latest `tar.xz` file.\
 Then run

--- a/README.md
+++ b/README.md
@@ -20,11 +20,19 @@ This is a wrapper for TIDAL's web app, using Nativfier, which injects custom cod
 Click the above tag, or go to the releases tab, and download the latest `tar.xz` file.\
 Then run
 ```
-tar xf tidal_desktop-vX.Y.Z.tar.xz
+tar xf tidal_desktop-gnome-vX.Y.Z.tar.xz
+cd tidal_desktop-gnome-v1.0.0
 chown -R 1000:1000 release
+gedit release/build/TIDAL-linux-x64/tidal.desktop
+```
+This will open a text editor. Replace YOUR_USER_HERE with your username, save and close the file.
+Then run
+```
 cd release
 ./deploy.sh
 ```
+You might need to restart your computer if TIDAL doesn't show up.
+
 Now you should be able to start TIDAL as any other desktop application.
 
 ### From source

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Click the above tag, or go to the releases tab, and download the latest `tar.xz`
 Then run
 ```
 tar xf tidal_desktop-gnome-vX.Y.Z.tar.xz
-cd tidal_desktop-gnome-vX.Y.Z
 chown -R 1000:1000 release
 gedit release/tidal.desktop
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Then run
 cd release
 ./deploy.sh
 ```
-You might need to restart your computer if TIDAL doesn't show up.
 
 Now you should be able to start TIDAL as any other desktop application.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then run
 tar xf tidal_desktop-gnome-vX.Y.Z.tar.xz
 cd tidal_desktop-gnome-vX.Y.Z
 chown -R 1000:1000 release
-gedit release/build/TIDAL-linux-x64/tidal.desktop
+gedit release/tidal.desktop
 ```
 This will open a text editor. Replace YOUR_USER_HERE with your username, save and close the file.
 Then run

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Click the above tag, or go to the releases tab, and download the latest `tar.xz`
 Then run
 ```
 tar xf tidal_desktop-gnome-vX.Y.Z.tar.xz
-cd tidal_desktop-gnome-v1.0.0
+cd tidal_desktop-gnome-vX.Y.Z
 chown -R 1000:1000 release
 gedit release/build/TIDAL-linux-x64/tidal.desktop
 ```


### PR DESCRIPTION
Hello.
I've edited the deploy.sh script to work on all shells. I recommend you test it on Arch and Debian though.
The script creates the tidal.desktop with the $HOME variable injected, rather than copying the tidal.desktop file (now you do not need to include it). 
You should also put the icon.png into TIDAL-linux-x64 folder.
I don't really know how the github's commits, and pulls, and stuff work, so I just attached the script.

P.S. Would be great to have it available on flatpak.
dxwil

[deploy.txt](https://github.com/rippin93/tidal-desktop/files/8008122/deploy.txt)